### PR TITLE
parser debug

### DIFF
--- a/src/infer.rs
+++ b/src/infer.rs
@@ -330,8 +330,12 @@ fn unify_many(mut ts_1: Vec<Type>, mut ts_2: Vec<Type>) -> Result<Subst, TypeErr
             (None, None) => Ok(HashMap::new()),
             (Some(t1), Some(t2)) => {
                 let subst_1 = unifies(t1, t2)?;
-                for t in ts_1.iter_mut() { *t = t.clone().apply(&subst_1) }
-                for t in ts_2.iter_mut() { *t = t.clone().apply(&subst_1) }
+                for t in ts_1.iter_mut() {
+                    *t = t.clone().apply(&subst_1)
+                }
+                for t in ts_2.iter_mut() {
+                    *t = t.clone().apply(&subst_1)
+                }
                 let subst_2 = unify_many(ts_1, ts_2)?;
                 Ok(compose(subst_2, subst_1))
             }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -55,7 +55,7 @@ where
 
     let fix = (res_str("fix"), expr()).map(|t| Expr::Fix(Box::new(t.1)));
 
-    let l_prefix = (char('l'), choice(( lam, let_ ))).map(|t| t.1);
+    let l_prefix = (char('l'), choice((lam, let_))).map(|t| t.1);
     let parenthesized = choice((l_prefix, if_, fix, app));
 
     choice((
@@ -146,7 +146,9 @@ where
     Input: Stream<Token = char>,
     Input::Error: ParseError<Input::Token, Input::Range, Input::Position>,
 {
-    string(x).skip(not_followed_by(alpha_num())).skip(skip_spaces())
+    string(x)
+        .skip(not_followed_by(alpha_num()))
+        .skip(skip_spaces())
 }
 
 fn name<Input>() -> impl Parser<Input, Output = Name>

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1,5 +1,5 @@
 use combine::error::ParseError;
-use combine::parser::char::{char, digit, letter, spaces, string};
+use combine::parser::char::{alpha_num, char, digit, letter, spaces, string};
 use combine::stream::Stream;
 use combine::{attempt, between, choice, many1, not_followed_by, optional, parser, Parser};
 
@@ -13,10 +13,9 @@ where
     Input::Error: ParseError<Input::Token, Input::Range, Input::Position>,
 {
     let l_bool = choice((
-        str_("true").map(|_| Lit::LBool(true)),
-        (str_("false").map(|_| Lit::LBool(false))),
-    ))
-    .skip(not_followed_by(letter()));
+        res_str("true").map(|_| Lit::LBool(true)),
+        (res_str("false").map(|_| Lit::LBool(false))),
+    ));
     let l_int = (optional(char('-')), integer()).map(|t| {
         // TODO handle this error, even though it should be impossible
         let string: String = t.1;
@@ -28,19 +27,19 @@ where
     });
     let lit = choice((l_bool, l_int)).map(|v| Expr::Lit(v));
 
-    let p_add = str_("+").map(|_| PrimOp::Add);
-    let p_sub = str_("-").map(|_| PrimOp::Sub);
-    let p_mul = str_("*").map(|_| PrimOp::Mul);
-    let p_eql = str_("==").map(|_| PrimOp::Eql);
+    let p_add = res_str("+").map(|_| PrimOp::Add);
+    let p_sub = res_str("-").map(|_| PrimOp::Sub);
+    let p_mul = res_str("*").map(|_| PrimOp::Mul);
+    let p_eql = res_str("==").map(|_| PrimOp::Eql);
     let prim_op = choice((p_add, p_sub, p_mul, p_eql)).map(|v| Expr::Prim(v));
 
     let app = (expr(), expr()).map(|t| Expr::App(Box::new(t.0), Box::new(t.1)));
 
-    let lam = (str_("lam "), lex_char('['), name(), lex_char(']'), expr())
+    let lam = (res_str("am"), lex_char('['), name(), lex_char(']'), expr())
         .map(|t| Expr::Lam(t.2, Box::new(t.4)));
 
     let let_ = (
-        str_("let "),
+        res_str("et"),
         lex_char('('),
         lex_char('['),
         name(),
@@ -51,12 +50,13 @@ where
     )
         .map(|t| Expr::Let(t.3, Box::new(t.4), Box::new(t.7)));
 
-    let if_ = (str_("if "), expr(), expr(), expr())
+    let if_ = (res_str("if"), expr(), expr(), expr())
         .map(|t| Expr::If(Box::new(t.1), Box::new(t.2), Box::new(t.3)));
 
-    let fix = (str_("fix "), expr()).map(|t| Expr::Fix(Box::new(t.1)));
+    let fix = (res_str("fix"), expr()).map(|t| Expr::Fix(Box::new(t.1)));
 
-    let parenthesized = choice((attempt(lam), attempt(let_), attempt(if_), attempt(fix), app));
+    let l_prefix = (char('l'), choice(( lam, let_ ))).map(|t| t.1);
+    let parenthesized = choice((l_prefix, if_, fix, app));
 
     choice((
         attempt(lit),
@@ -88,7 +88,7 @@ where
     // Necessary due to rust-lang/rust#24159
     Input::Error: ParseError<Input::Token, Input::Range, Input::Position>,
 {
-    let defn_ = (str_("defn "), name(), expr()).map(|t| Defn(t.1, t.2));
+    let defn_ = (res_str("defn"), name(), expr()).map(|t| Defn(t.1, t.2));
 
     between(lex_char('('), lex_char(')'), defn_).skip(skip_spaces())
 }
@@ -141,12 +141,12 @@ where
     many1(digit()).skip(skip_spaces())
 }
 
-fn str_<'a, Input>(x: &'static str) -> impl Parser<Input, Output = &'a str>
+fn res_str<'a, Input>(x: &'static str) -> impl Parser<Input, Output = &'a str>
 where
     Input: Stream<Token = char>,
     Input::Error: ParseError<Input::Token, Input::Range, Input::Position>,
 {
-    string(x).skip(skip_spaces())
+    string(x).skip(not_followed_by(alpha_num())).skip(skip_spaces())
 }
 
 fn name<Input>() -> impl Parser<Input, Output = Name>

--- a/src/pretty.rs
+++ b/src/pretty.rs
@@ -1,8 +1,8 @@
 use pretty::RcDoc;
 
 use super::syntax::{Defn, Expr, Expr::*, Lit, Lit::*, Name, PrimOp, PrimOp::*};
-use crate::util::pretty::parens;
 use crate::sp;
+use crate::util::pretty::parens;
 
 impl Expr {
     pub fn ppr(&self) -> RcDoc<()> {

--- a/src/test/syntax.rs
+++ b/src/test/syntax.rs
@@ -1,6 +1,7 @@
 use quickcheck::{empty_shrinker, single_shrinker, Arbitrary, Gen};
 use rand::Rng;
 
+use crate::parse::reserved;
 use crate::syntax::*;
 
 impl Arbitrary for Expr {
@@ -113,11 +114,16 @@ impl Arbitrary for Lit {
 impl Arbitrary for Name {
     fn arbitrary<G: Gen>(g: &mut G) -> Name {
         let len = g.gen_range(3, 8);
-        let mut s = String::new();
-        for _ in 0..len {
-            s.push(gen_alpha_char(g));
+        let res = reserved();
+        loop {
+            let mut s = String::new();
+            for _ in 0..len {
+                s.push(gen_alpha_char(g));
+            }
+            if !res.contains(&s) {
+                return Name(s);
+            }
         }
-        Name(s)
     }
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,7 +1,7 @@
 use pretty::RcDoc;
 
-use crate::util::pretty::parens;
 use crate::sp;
+use crate::util::pretty::parens;
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Hash)]
 pub struct TV(pub String);
@@ -34,7 +34,9 @@ impl Scheme {
                     RcDoc::text("")
                 } else {
                     let vars: Vec<RcDoc<()>> = tvs.iter().map(|tv| tv.ppr()).collect();
-                    RcDoc::text("forall ").append(RcDoc::intersperse(vars, sp!())).append(RcDoc::text(". "))
+                    RcDoc::text("forall ")
+                        .append(RcDoc::intersperse(vars, sp!()))
+                        .append(RcDoc::text(". "))
                 };
 
                 quantifier.append(ty.ppr())
@@ -46,7 +48,7 @@ impl Scheme {
 impl TV {
     pub fn ppr(&self) -> RcDoc<()> {
         match self {
-            TV(s) => RcDoc::text(s)
+            TV(s) => RcDoc::text(s),
         }
     }
 }


### PR DESCRIPTION
some misc fixes for some weird parser behavior.

examples which didn't work before and now do:

* `(true true)` - parsed the first `true` as a variable, not a literal
* `(lam [x] (if true x x))` - same thing ^

not exactly sure what was happening, but I think it had to do with `str_` and the extra spaces I had on the ends of reserved keywords...

***

unrelated `cargo fmt` cleanup from past PR. oops.