### PR TITLE
eval

### DIFF
--- a/src/env.rs
+++ b/src/env.rs
@@ -63,9 +63,9 @@ impl Env {
         hm.keys().map(|x| x.clone()).collect()
     }
 
-    pub fn replace(&mut self, nm: Name, sc: Scheme) {
+    pub fn replace(&mut self, nm: &Name, sc: Scheme) {
         self.remove(nm.clone());
-        self.extend(nm, sc);
+        self.extend(nm.clone(), sc);
     }
 }
 

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -1,0 +1,137 @@
+use pretty::RcDoc;
+use std::collections::HashMap;
+
+use super::syntax::{Expr, Lit, Name, PrimOp};
+use crate::{app, lam};
+
+#[derive(Clone)]
+pub enum Value {
+    VInt(i64),
+    VBool(bool),
+    VClosure(Name, Box<Expr>, TermEnv),
+}
+
+type TermEnv = HashMap<Name, Value>;
+
+impl Value {
+    pub fn ppr(&self) -> RcDoc<()> {
+        match self {
+            VInt(n) => RcDoc::as_string(n),
+            VBool(true) => RcDoc::text("true"),
+            VBool(false) => RcDoc::text("false"),
+            VClosure(_, _, _) => RcDoc::text("<<closure>>"),
+        }
+    }
+}
+
+struct EvalState(u64);
+
+impl EvalState {
+    fn new() -> EvalState {
+        EvalState(0)
+    }
+
+    fn fresh(&mut self) -> Name {
+        let cnt = match self {
+            EvalState(c) => {
+                *c += 1;
+                *c
+            }
+        };
+        let s = format!("_{}", cnt);
+        Name(s)
+    }
+}
+
+pub fn eval(expr: Expr) -> Value {
+    let env = HashMap::new();
+    let mut es = EvalState::new();
+    eval_(&env, &mut es, expr)
+}
+
+use Value::*;
+fn eval_(env: &TermEnv, es: &mut EvalState, expr: Expr) -> Value {
+    match find_prim_app(&expr) {
+        Some((op, args)) => {
+            let args_v: Vec<Value> = args.iter().map(|arg| eval_(env, es, arg.clone())).collect();
+            match op {
+                PrimOp::Add => match (&args_v[0], &args_v[1]) {
+                    (VInt(a_), VInt(b_)) => VInt(a_ + b_),
+                    _ => panic!("+: bad types"),
+                },
+                PrimOp::Sub => match (&args_v[0], &args_v[1]) {
+                    (VInt(a_), VInt(b_)) => VInt(a_ - b_),
+                    _ => panic!("-: bad types"),
+                },
+                PrimOp::Mul => match (&args_v[0], &args_v[1]) {
+                    (VInt(a_), VInt(b_)) => VInt(a_ * b_),
+                    _ => panic!("*: bad types"),
+                },
+                PrimOp::Eql => match (&args_v[0], &args_v[1]) {
+                    (VInt(a_), VInt(b_)) => VBool(a_ == b_),
+                    _ => panic!("==: bad types"),
+                },
+            }
+        }
+
+        None => match expr {
+            Expr::Lit(Lit::LInt(x)) => VInt(x),
+            Expr::Lit(Lit::LBool(x)) => VBool(x),
+
+            Expr::Var(x) => match env.get(&x) {
+                None => panic!("impossible: free variable: {:?}", x),
+                Some(v) => v.clone(),
+            },
+
+            Expr::Lam(nm, bd) => VClosure(nm, bd, env.clone()),
+
+            Expr::Let(x, e, bd) => {
+                let e_v = eval_(env, es, *e);
+                let mut new_env = env.clone();
+                new_env.insert(x, e_v);
+                eval_(&new_env, es, *bd)
+            }
+
+            Expr::If(tst, thn, els) => match eval_(env, es, *tst) {
+                VBool(true) => eval_(env, es, *thn),
+                VBool(false) => eval_(env, es, *els),
+                _ => panic!("impossible: non-bool in test position of if"),
+            },
+
+            Expr::Prim(op) => {
+                let nm1 = es.fresh();
+                let nm2 = es.fresh();
+                let bd = app!(
+                    app!(Expr::Prim(op), Expr::Var(nm1.clone())),
+                    Expr::Var(nm2.clone())
+                );
+                let inner = lam!(nm2, bd);
+                VClosure(nm1, Box::new(inner), env.clone())
+            }
+
+            Expr::App(fun, arg) => match eval_(env, es, *fun) {
+                VClosure(nm, bd, clo) => {
+                    let arg_v = eval_(env, es, *arg);
+                    let mut new_env = clo.clone();
+                    new_env.insert(nm, arg_v);
+                    eval_(&new_env, es, *bd)
+                }
+                _ => panic!("impossible: non-closure in function position of app"),
+            },
+
+            Expr::Fix(e) => eval_(env, es, Expr::App(e.clone(), Box::new(Expr::Fix(e)))),
+        },
+    }
+}
+
+fn find_prim_app(expr: &Expr) -> Option<(PrimOp, Vec<Expr>)> {
+    match expr {
+        Expr::App(fun, arg) => {
+            let (op, mut args) = find_prim_app(fun)?;
+            args.push(*arg.clone());
+            Some((op, args))
+        }
+        Expr::Prim(op) => Some((op.clone(), Vec::new())),
+        _ => None,
+    }
+}

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -53,7 +53,10 @@ use Value::*;
 fn eval_(env: &TermEnv, es: &mut EvalState, expr: &Expr) -> Value {
     match find_prim_app(&expr) {
         Some((op, args)) => {
-            let args_v: Vec<Value> = args.iter().map(|arg| eval_(env, es, &arg.clone())).collect();
+            let args_v: Vec<Value> = args
+                .iter()
+                .map(|arg| eval_(env, es, &arg.clone()))
+                .collect();
             match op {
                 PrimOp::Add => match (&args_v[0], &args_v[1]) {
                     (VInt(a_), VInt(b_)) => VInt(a_ + b_),
@@ -119,7 +122,11 @@ fn eval_(env: &TermEnv, es: &mut EvalState, expr: &Expr) -> Value {
                 _ => panic!("impossible: non-closure in function position of app"),
             },
 
-            Expr::Fix(e) => eval_(env, es, &Expr::App(e.clone(), Box::new(Expr::Fix(e.clone())))),
+            Expr::Fix(e) => eval_(
+                env,
+                es,
+                &Expr::App(e.clone(), Box::new(Expr::Fix(e.clone()))),
+            ),
         },
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ extern crate quickcheck;
 extern crate quickcheck_macros;
 
 pub mod env;
+pub mod eval;
 pub mod infer;
 pub mod parse;
 pub mod pretty;

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,11 +34,11 @@ fn main() {
                         } else {
                             println!("ast: {:?}\n", e);
                             let env = Env::new();
-                            match infer_expr(env, e) {
+                            match infer_expr(env, &e) {
                                 Err(err) => println!("type error: {:?}", err),
                                 Ok(sc) => {
                                     println!("scheme: {}", to_pretty(sc.ppr(), width));
-                                    println!("value: {}", to_pretty(eval(e).ppr(), width));
+                                    println!("value: {}", to_pretty(eval(&e).ppr(), width));
                                 }
                             }
                         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,7 @@ use combine::parser::Parser;
 use combine::stream::easy;
 use rustyline::{error::ReadlineError, Editor};
 
-use poly::{env::*, infer::*, parse::expr, util::pretty::to_pretty};
+use poly::{env::*, eval::eval, infer::*, parse::expr, util::pretty::to_pretty};
 
 const BANNER: &'static str = r#"
                  __
@@ -38,6 +38,7 @@ fn main() {
                                 Err(err) => println!("type error: {:?}", err),
                                 Ok(sc) => {
                                     println!("scheme: {}", to_pretty(sc.ppr(), width));
+                                    println!("value: {}", to_pretty(eval(e).ppr(), width));
                                 }
                             }
                         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,8 +37,9 @@ fn main() {
                             match infer_expr(env, &e) {
                                 Err(err) => println!("type error: {:?}", err),
                                 Ok(sc) => {
-                                    println!("scheme: {}", to_pretty(sc.ppr(), width));
-                                    println!("value: {}", to_pretty(eval(&e).ppr(), width));
+                                    let ty = to_pretty(sc.ppr(), width);
+                                    let val = to_pretty(eval(&e).ppr(), width);
+                                    println!("(: {}\n   {}\n)", val, ty);
                                 }
                             }
                         }

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -13,6 +13,20 @@ pub enum Expr {
     Prim(PrimOp),
 }
 
+#[macro_export]
+macro_rules! app {
+    ( $a: expr, $b: expr ) => {
+        Expr::App(Box::new($a), Box::new($b))
+    };
+}
+
+#[macro_export]
+macro_rules! lam {
+    ( $a: expr, $b: expr ) => {
+        Expr::Lam($a, Box::new($b))
+    };
+}
+
 #[derive(Clone, Debug, PartialEq)]
 pub enum Lit {
     LInt(i64),


### PR DESCRIPTION
add `eval`, which evaluates / interprets `Expr` types into `Value`s.

I take a slightly deviant approach (from the original `poly` tutorial) here. I allow primitive ops to float freely in the AST, and then do an analysis pass where I check for "direct" applications of primitives and evaluate those immediately.

compare [poly tutorial](https://github.com/sdiehl/write-you-a-haskell/blob/master/chapter7/poly_constraints/src/Eval.hs#L33-L36) and [my code](https://github.com/mhuesch/poly-rs/blob/3ea929d06e8f0d6d6df4c05d21488025995e8cea/src/eval.rs#L56). note that my `PrimOp` is a terminal which may be applied, rather than a non-terminal representing application of the primitive.